### PR TITLE
Feature Added: Wrap image edges in X or Y

### DIFF
--- a/node.py
+++ b/node.py
@@ -37,8 +37,8 @@ class TiledImageGenerator:
                 "steps": ("INT", {"default": 20, "min": 1, "max": 100}),
                 "cfg": ("FLOAT", {"default": 7.0, "min": 1.0, "max": 20.0, "step": 0.1}),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "control_after_generate": True}),
-                "seamlessX": ("BOOLEAN", {"default": True, "tooltip": "If true, side of image will be seamless."}),
-                "seamlessY": ("BOOLEAN", {"default": False, "tooltip": "If true, top/bottom of image will be seamless."}),
+                "seamlessX": ("BOOLEAN", {"default": True, "tooltip": "If true, side of image will be seamless. (2+ tiles)"}),
+                "seamlessY": ("BOOLEAN", {"default": False, "tooltip": "If true, top/bottom of image will be seamless. (2+ tiles)"}),
             }
         }
 

--- a/node.py
+++ b/node.py
@@ -37,6 +37,7 @@ class TiledImageGenerator:
                 "steps": ("INT", {"default": 20, "min": 1, "max": 100}),
                 "cfg": ("FLOAT", {"default": 7.0, "min": 1.0, "max": 20.0, "step": 0.1}),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "control_after_generate": True}),
+                "seamlessX": ("BOOLEAN", {"default": True, "tooltip": "If true, side of image will be seamless."}),
                 "seamlessY": ("BOOLEAN", {"default": False, "tooltip": "If true, top/bottom of image will be seamless."}),
             }
         }

--- a/node_advanced.py
+++ b/node_advanced.py
@@ -32,8 +32,8 @@ class TiledImageGeneratorAdvanced:
                 "controlnet": ("CONTROL_NET",),
                 "controlnet_strength": ("FLOAT", {"default": 0.7, "min": 0.0, "max": 1.0, "step": 0.01}),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "control_after_generate": True}),
-                "seamlessX": ("BOOLEAN", {"default": True, "tooltip": "If true, left/right of image will be seamless."}),
-                "seamlessY": ("BOOLEAN", {"default": False, "tooltip": "If true, top/bottom of image will be seamless."}),
+                "seamlessX": ("BOOLEAN", {"default": True, "tooltip": "If true, left/right of image will be seamless. (2+ tiles)"}),
+                "seamlessY": ("BOOLEAN", {"default": False, "tooltip": "If true, top/bottom of image will be seamless. (2+ tiles)"}),
             }
         }
 


### PR DESCRIPTION
I added the option to make seamless images in X or Y.
If you enable seamlessX or seamlessY and have 2 or more tiles in your grid then they will use the opposite edge to generate it's image.

![deepseek_00219_](https://github.com/user-attachments/assets/8ec1e105-e90c-491e-9a13-ab5a0a9b701f)

There was also something wrong with the JSON handling where it wasn't reading the tiles in the correct order depending how you had it laid out that has been fixed.
